### PR TITLE
action: handle ko images

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
       shell: bash
       run: |
         cid=$(docker create quay.io/lvh-images/lvh:${{ inputs.lvh-version }})
-        docker cp $cid:/usr/bin/lvh /bin/lvh
+        docker cp $cid:/usr/bin/lvh /bin/lvh || docker cp $cid:/ko-app/lvh /bin/lvh
         docker rm $cid
     - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
       if: ${{ inputs.provision == 'true' }}

--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,8 @@ runs:
       shell: bash
       run: |
         cid=$(docker create quay.io/lvh-images/lvh:${{ inputs.lvh-version }})
-        docker cp $cid:/usr/bin/lvh /bin/lvh || docker cp $cid:/ko-app/lvh /bin/lvh
+        sudo docker cp $cid:/usr/bin/lvh /bin/lvh || sudo docker cp $cid:/ko-app/lvh /bin/lvh
+        sudo chmod +x /bin/lvh
         docker rm $cid
     - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
       if: ${{ inputs.provision == 'true' }}
@@ -62,7 +63,7 @@ runs:
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        mkdir /_images
+        sudo mkdir -p /_images && sudo chmod 777 /_images
         docker run -v /_images:/mnt/images quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} cp /data/images/${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst /mnt/images
     - name: Prepare VM image
       if: ${{ inputs.provision == 'true'  }}
@@ -70,6 +71,7 @@ runs:
       run: |
         cd /_images
         zstd -d ${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst -o ${{ inputs.test-name }}.qcow2
+        chmod +rw ${{ inputs.test-name }}.qcow2
 
     - name: Start VM
       if: ${{ inputs.provision == 'true' }}


### PR DESCRIPTION
This commit [0] in LVH changed the lvh path in the container images to /ko-app/lvh. Update the docker cp command here to handle this as an alternative.

[0]: https://github.com/cilium/little-vm-helper/commit/1b718e7a03242e35a89fbd6cbfdd2dc0be663e1d

Signed-off-by: William Findlay <will@isovalent.com>