### PR TITLE
chore: fix permission errors and support versioned image tags

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -63,13 +63,13 @@ runs:
       shell: bash
       run: |
         sudo mkdir -p /_images && sudo chmod 777 /_images
-        docker run -v /_images:/mnt/images quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} cp /data/images/${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst /mnt/images
+        docker run -v /_images:/mnt/images quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} \'cp /data/images/*.qcow2.zst /mnt/images\'
     - name: Prepare VM image
       if: ${{ inputs.provision == 'true'  }}
       shell: bash
       run: |
         cd /_images
-        zstd -d ${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst -o ${{ inputs.test-name }}.qcow2
+        zstd -d *.qcow2.zst -o ${{ inputs.test-name }}.qcow2
         chmod +rw ${{ inputs.test-name }}.qcow2
 
     - name: Start VM

--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
       shell: bash
       run: |
         cid=$(docker create quay.io/lvh-images/lvh:${{ inputs.lvh-version }})
-        docker cp $cid:/usr/bin/lvh /bin/lvh
+        sudo docker cp $cid:/usr/bin/lvh /bin/lvh
         docker rm $cid
     - uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
       if: ${{ inputs.provision == 'true' }}
@@ -62,7 +62,7 @@ runs:
       if: ${{ inputs.provision == 'true' && steps.cache-lvh-image.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        mkdir /_images
+        sudo mkdir -p /_images && sudo chmod 777 /_images
         docker run -v /_images:/mnt/images quay.io/lvh-images/${{ inputs.image }}:${{ inputs.image-version }} cp /data/images/${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst /mnt/images
     - name: Prepare VM image
       if: ${{ inputs.provision == 'true'  }}
@@ -70,12 +70,13 @@ runs:
       run: |
         cd /_images
         zstd -d ${{ inputs.image }}_${{ inputs.image-version }}.qcow2.zst -o ${{ inputs.test-name }}.qcow2
+        chmod +rw ${{ inputs.test-name }}.qcow2
 
     - name: Start VM
       if: ${{ inputs.provision == 'true' }}
       shell: bash
       run: |
-        /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /_images/${{ inputs.test-name }}.qcow2 --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }}
+        sudo /bin/lvh run --host-mount=${{ inputs.host-mount }} --image /_images/${{ inputs.test-name }}.qcow2 --daemonize -p ${{ inputs.ssh-port }}:22 --serial-port ${{ inputs.serial-port }}
 
     - name: Run test cmd in VM
       shell: bash


### PR DESCRIPTION
Using /_images was resulting in permission errors on standard GA runners since we are not running the action as root. Rectify this by creating the directory with root privileges.
Also, some additional fixes for permission errors around copying the lvh bin out of the container and being able to read and write the qcow image.

The second commit updates the expected pathname for the zstd compressed qcow2 image to support versioned image tags.