### PR TITLE
Archive the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+This repository is ARCHIVED. See https://github.com/cilium/little-vm-helper for
+the latest version of the little-vm-helper github action.


### PR DESCRIPTION
The latest version of this action seems to live in
https://github.com/cilium/little-vm-helper now, so we should archive this
repository to make it more clear.
